### PR TITLE
Kernel changes

### DIFF
--- a/pycbc/inference/models/lisa_pre_merger.py
+++ b/pycbc/inference/models/lisa_pre_merger.py
@@ -100,7 +100,6 @@ class LISAPreMergerModel(BaseModel):
         self.window_length = window_length
         self.sample_rate = sample_rate
         self.cutoff_time = cutoff_time
-        # TODO: this now samples
         self.extra_forward_zeroes = extra_forward_zeroes
 
         # Load the data from the file
@@ -113,7 +112,7 @@ class LISAPreMergerModel(BaseModel):
 
         # Pre-process the pre-merger data
         # Returns time-domain data
-        # Uses UIDs: 4235(0), 4236(0)
+        # Uses UIDs: 4235, 4236
         logging.info("Pre-processing pre-merger data")
         pre_merger_data = pre_process_data_lisa_pre_merger(
             data,
@@ -148,7 +147,7 @@ class LISAPreMergerModel(BaseModel):
         """
         # Generate the pre-merger waveform
         # These waveforms are whitened
-        # Uses UIDs: 1234(0), 1235(0), 1236(0), 1237(0)
+        # Uses UIDs: 1235(0), 1236(0)
         ws = generate_waveform_lisa_pre_merger(
             params,
             psds_for_whitening=self.whitening_psds,

--- a/pycbc/inference/models/lisa_pre_merger.py
+++ b/pycbc/inference/models/lisa_pre_merger.py
@@ -64,7 +64,6 @@ class LISAPreMergerModel(BaseModel):
         # Pop relevant values from kwargs
         cutoff_time = int(kwargs.pop('cutoff_time'))
         kernel_length = int(kwargs.pop('kernel_length'))
-        psd_kernel_length = int(kwargs.pop('psd_kernel_length'))
         window_length = int(kwargs.pop('window_length'))
         extra_forward_zeroes = int(kwargs.pop('extra_forward_zeroes'))
         tlen = int(kwargs.pop('tlen'))
@@ -87,13 +86,13 @@ class LISAPreMergerModel(BaseModel):
             psd_file,
             sample_rate=sample_rate,
             duration=tlen,
-            kernel_length=psd_kernel_length,
+            kernel_length=kernel_length,
         )["FD"]
         self.whitening_psds['LISA_E'] = generate_pre_merger_psds(
             psd_file,
             sample_rate=sample_rate,
             duration=tlen,
-            kernel_length=psd_kernel_length,
+            kernel_length=kernel_length,
         )["FD"]
 
         # Store data for doing likelihoods.
@@ -101,6 +100,7 @@ class LISAPreMergerModel(BaseModel):
         self.window_length = window_length
         self.sample_rate = sample_rate
         self.cutoff_time = cutoff_time
+        # TODO: this now samples
         self.extra_forward_zeroes = extra_forward_zeroes
 
         # Load the data from the file
@@ -119,9 +119,9 @@ class LISAPreMergerModel(BaseModel):
             data,
             sample_rate=sample_rate,
             psds_for_whitening=self.whitening_psds,
-            window_length=self.window_length, 
+            window_length=0, 
             cutoff_time=self.cutoff_time,
-            extra_forward_zeroes=self.extra_forward_zeroes,
+            forward_zeroes=self.kernel_length,
         )
 
         self.lisa_a_strain = pre_merger_data["LISA_A"]
@@ -155,7 +155,7 @@ class LISAPreMergerModel(BaseModel):
             window_length=self.window_length,
             sample_rate=self.sample_rate,
             cutoff_time=self.cutoff_time,
-            extra_forward_zeroes=self.extra_forward_zeroes,
+            forward_zeroes=self.extra_forward_zeroes + self.kernel_length,
         )
 
         wf = {}

--- a/pycbc/waveform/pre_merger_waveform.py
+++ b/pycbc/waveform/pre_merger_waveform.py
@@ -267,8 +267,7 @@ def generate_waveform_lisa_pre_merger(
         the window will be applied starting after the zeroes.
     """
     window = get_window(window_length)
-    
-    nctf = int(cutoff_time * sample_rate)
+    nctf = int((cutoff_time + waveform_params["cutoff_deltat"]) * sample_rate)
 
     outs = pycbc.waveform.get_fd_det_waveform(
         ifos=['LISA_A','LISA_E'], **waveform_params

--- a/pycbc/waveform/pre_merger_waveform.py
+++ b/pycbc/waveform/pre_merger_waveform.py
@@ -16,21 +16,21 @@ def get_window(window_length):
 
 
 def apply_pre_merger_kernel(
-    tout,
+    f_series,
     whitening_psd,
     window,
     window_length,
-    nefz,
+    nfz,
     nctf,
-    uids,
+    uid,
     copy_output=False,
 ):
     """Helper function to apply the pre-merger kernel.
     
     Parameters
     ----------
-    tout : pycbc.types.TimeSeries
-        Time series to apply the kernel to.
+    f_series : pycbc.types.FrequencySeries
+        Frequency series to apply the kernel to.
     whitening_psd : pycbc.types.FrequencySeries
         PSD for whitening the data in the frequency-domain.
     window : numpy.ndarray
@@ -38,37 +38,31 @@ def apply_pre_merger_kernel(
     window_length : int
         Pre-computed length of the window in samples.
     nefz : int
-        Number of extra forward zeroes.
+        Number of forward zeroes.
     nctf : int
         Number of samples to zero at the end of the data.
-    uids : tuple
-        Unique UIDs for computing the (i)FFTs. Must be length 2.
+    uid : int
+        UIDs for computing the iFFTs.
 
     Returns
     -------
     pycbc.types.TimeSeries
         Whitened time series.
     """
-    # TD to FD for whitening 
-    fout = pycbc.strain.strain.execute_cached_fft(
-        tout,
-        copy_output=copy_output,
-        uid=uids[0],
-    )
     # Whiten data
-    fout.data[:] = fout.data[:] * (whitening_psd.data[:]).conj()
+    f_series.data[:] = f_series.data[:] * (whitening_psd.data[:]).conj()
 
-    # TD to FD to reapply zeroes
+    # TD to FD to apply zeroes
     tout_ww = pycbc.strain.strain.execute_cached_ifft(
-        fout,
+        f_series,
         copy_output=copy_output,
-        uid=uids[1],
+        uid=uid,
     )
     # Zero initial data
-    tout_ww.data[:nefz] = 0
+    tout_ww.data[:nfz] = 0
     if window is not None:
         # Apply window
-        tout_ww.data[nefz:nefz+window_length] *= window
+        tout_ww.data[nfz:nfz+window_length] *= window
     # Zero data from cutoff
     tout_ww.data[-nctf:] = 0
     return tout_ww
@@ -95,9 +89,6 @@ def generate_data_lisa_pre_merger(
         PSDs for data generation.
     sample_rate : float
         Sampling rate in Hz. 
-    extra_forward_zeros : float
-        Time (in seconds) to set to zero at the start of the waveform. If used,
-        the window will be applied starting after the zeroes.
     seed : int
         Random seed used for generating the noise.
     zero_noise : bool
@@ -205,8 +196,8 @@ def pre_process_data_lisa_pre_merger(
         Length of the hann window use to taper the start of the data.
     cutoff_time : float
         Time (in seconds) from the end of the waveform to cutoff.
-    extra_forward_zeros : float
-        Time (in seconds) to set to zero at the start of the waveform. If used,
+    forward_zeroes : float
+        Number of samples to set to zero at the start of the waveform. If used,
         the window will be applied starting after the zeroes.
 
     Returns
@@ -220,25 +211,26 @@ def pre_process_data_lisa_pre_merger(
     nctf = int(cutoff_time * sample_rate)
 
     # Apply pre-merger kernel to both channels
+    # Function needs frequency series
     strain_ww = {}
     strain_ww["LISA_A"] = apply_pre_merger_kernel(
-        data["LISA_A"],
+        data["LISA_A"].to_frequencyseries(),
         whitening_psd=psds_for_whitening["LISA_A"],
         window=window,
         window_length=window_length,
-        nefz=forward_zeroes,
+        nfz=forward_zeroes,
         nctf=nctf,
-        uids=(4235, 4236),
+        uid=4235,
         copy_output=True,
     )
     strain_ww["LISA_E"] = apply_pre_merger_kernel(
-        data["LISA_E"],
+        data["LISA_E"].to_frequencyseries(),
         whitening_psd=psds_for_whitening["LISA_E"],
         window=window,
         window_length=window_length,
-        nefz=forward_zeroes,
+        nfz=forward_zeroes,
         nctf=nctf,
-        uids=(42350, 42360),
+        uid=4236,
         copy_output=True,
     )
     return strain_ww
@@ -270,51 +262,36 @@ def generate_waveform_lisa_pre_merger(
         waveform.
     cutoff_time: float
         Time (in seconds) from the end of the waveform to cutoff.
-    kernel_length : int
-        Unused.
-    extra_forward_zeroes : int
-        Time (in seconds) to set to zero at the start of the waveform. If used,
+    forward_zeroes : int
+        Number of samples to set to zero at the start of the waveform. If used,
         the window will be applied starting after the zeroes.
     """
     window = get_window(window_length)
     
     nctf = int(cutoff_time * sample_rate)
 
-    # FIXME: do we need to generate LISA_T
     outs = pycbc.waveform.get_fd_det_waveform(
         ifos=['LISA_A','LISA_E'], **waveform_params
     )
 
-    # FD waveform to TD so we can apply pre-merger kernel
-    tout_A = pycbc.strain.strain.execute_cached_ifft(
-        outs["LISA_A"],
-        copy_output=False,
-        uid=1234,
-    )
-    tout_E = pycbc.strain.strain.execute_cached_ifft(
-        outs["LISA_E"],
-        copy_output=False,
-        uid=12340,
-    )
-
     # Apply pre-merger kernel
     tout_A_ww = apply_pre_merger_kernel(
-        tout_A,
+        outs["LISA_A"],
         whitening_psd=psds_for_whitening["LISA_A"],
         window=window,
         window_length=window_length,
-        nefz=forward_zeroes,
+        nfz=forward_zeroes,
         nctf=nctf,
-        uids=(1235, 1236),
+        uid=1235,
     )
     tout_E_ww = apply_pre_merger_kernel(
-        tout_E,
+        outs["LISA_E"],
         whitening_psd=psds_for_whitening["LISA_E"],
         window=window,
         window_length=window_length,
-        nefz=forward_zeroes,
+        nfz=forward_zeroes,
         nctf=nctf,
-        uids=(12350, 12360),
+        uid=12350,
     )
     
     # Back to FD for search/inference
@@ -322,11 +299,11 @@ def generate_waveform_lisa_pre_merger(
     fouts_ww["LISA_A"] = pycbc.strain.strain.execute_cached_fft(
         tout_A_ww,
         copy_output=False,
-        uid=1237,
+        uid=1236,
     )
     fouts_ww["LISA_E"] = pycbc.strain.strain.execute_cached_fft(
         tout_E_ww,
         copy_output=False,
-        uid=12370,
+        uid=12360,
     )
     return fouts_ww

--- a/pycbc/waveform/pre_merger_waveform.py
+++ b/pycbc/waveform/pre_merger_waveform.py
@@ -42,7 +42,7 @@ def apply_pre_merger_kernel(
     nctf : int
         Number of samples to zero at the end of the data.
     uid : int
-        UIDs for computing the iFFTs.
+        UID for computing the iFFTs.
 
     Returns
     -------


### PR DESCRIPTION
Changes to the pre-merger kernel as discussed with @spxiwh.

**Summary**

- Data is no longer windowed
- Waveforms now have the `kernel_length + extra_forward_zeroes` set to zero
- `apply_pre_merger_kernel` now takes an FD input and applies the zeroing and optional windowing **after** whitening
- Add `cutoff_deltat` to inference to account for the additional end data added to the injections.


**To-Do**

- [x] Data checks
- [x] Waveform checks
- [x] Inference check

