### PR TITLE
Correct the harmonic_waveform_plot and make single_template work for THA runs 

### DIFF
--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -38,6 +38,8 @@ parser.add_argument('--statmap-file',
                     help="HDF format clustered coincident trigger result file")
 parser.add_argument('--single-detector-triggers', nargs='+', action=MultiDetOptionAction,
                     help="HDF format merged single detector trigger files")
+parser.add_argument('--psd-files', nargs='+', action=MultiDetOptionAction,
+                    help="Merged PSD files")
 parser.add_argument('--inspiral-segments',
                     help="xml segment files containing the inspiral analysis times")
 parser.add_argument('--inspiral-data-read-name',
@@ -222,10 +224,13 @@ while event_count < num_events and curr_idx < (events_to_read - 1):
     _, sngl_tmplt_plots = mini.make_single_template_plots(
         workflow,
         insp_segs,
+        single_triggers,
+        tmpltbank_file,
         args.inspiral_data_read_name,
         args.inspiral_data_analyzed_name,
         params,
         args.output_dir,
+        special_tids=ifo_tids,
         data_segments=insp_data_seglists,
         tags=args.tags + [str(event_count)]
     )

--- a/bin/minifollowups/pycbc_foreground_minifollowup
+++ b/bin/minifollowups/pycbc_foreground_minifollowup
@@ -81,6 +81,7 @@ coinc_file = resolve_url_to_file(os.path.abspath(args.statmap_file))
 insp_segs = resolve_url_to_file(os.path.abspath(args.inspiral_segments))
 
 single_triggers = []
+psd_files = []
 fsdt = {}
 insp_data_seglists = {}
 insp_analysed_seglists = {}
@@ -89,6 +90,13 @@ for ifo in args.single_detector_triggers:
     strig_file = resolve_url_to_file(os.path.abspath(fname),
                                      attrs={'ifos': ifo})
     single_triggers.append(strig_file)
+    psd_files.append(
+        resolve_url_to_file(
+            os.path.abspath(args.psd_files[ifo]),
+            attrs={'ifos': ifo},
+        )
+    )
+
     fsdt[ifo] = HFile(args.single_detector_triggers[ifo], 'r')
     insp_data_seglists[ifo] = select_segments_by_definer(
         args.inspiral_segments,
@@ -211,6 +219,11 @@ while event_count < num_events and curr_idx < (events_to_read - 1):
     files += mini.make_trigger_timeseries(workflow, single_triggers,
                              ifo_times, args.output_dir, special_tids=ifo_tids,
                              tags=args.tags + [str(event_count)])
+
+    files += mini.make_harmonic_waveform(workflow, single_triggers,
+                              tmpltbank_file, psd_files,
+                              args.output_dir, special_tids=ifo_tids,
+                              tags=args.tags + [str(event_count)])
 
     params = mini.get_single_template_params(
         curr_idx,

--- a/bin/minifollowups/pycbc_injection_minifollowup
+++ b/bin/minifollowups/pycbc_injection_minifollowup
@@ -129,6 +129,8 @@ parser.add_argument('--injection-xml-file',
                     help="XML format injection file")
 parser.add_argument('--single-detector-triggers', nargs='+', action=MultiDetOptionAction,
                     help="HDF format merged single detector trigger files")
+parser.add_argument('--psd-files', nargs='+', action=MultiDetOptionAction,
+                    help="Merged PSD files")
 parser.add_argument('--inspiral-segments',
                     help="xml segment files containing the inspiral analysis times")
 parser.add_argument('--inspiral-data-read-name',
@@ -356,6 +358,8 @@ for num_event in range(num_events):
             )
 
     _, norm_plot = mini.make_single_template_plots(workflow, insp_segs,
+                            single_triggers,
+                            tmpltbank_file,
                             args.inspiral_data_read_name,
                             args.inspiral_data_analyzed_name, inj_params,
                             args.output_dir, inj_file=injection_xml_file,
@@ -366,6 +370,8 @@ for num_event in range(num_events):
     files += norm_plot
 
     _, inv_plot = mini.make_single_template_plots(workflow, insp_segs,
+                            single_triggers,
+                            tmpltbank_file,
                             args.inspiral_data_read_name,
                             args.inspiral_data_analyzed_name, inj_params,
                             args.output_dir, inj_file=injection_xml_file,
@@ -377,6 +383,8 @@ for num_event in range(num_events):
     files += inv_plot
 
     _, noinj_plot = mini.make_single_template_plots(workflow, insp_segs,
+                            single_triggers,
+                            tmpltbank_file,
                             args.inspiral_data_read_name,
                             args.inspiral_data_analyzed_name, inj_params,
                             args.output_dir, inj_file=injection_xml_file,
@@ -387,6 +395,7 @@ for num_event in range(num_events):
                             use_exact_inj_params=True)
     files += noinj_plot
 
+    ifo_tids_strings = []
     for curr_ifo in args.single_detector_triggers:
         # Finding loudest template in this detector near to the injection:
         # First, find triggers close to the missed injection
@@ -411,38 +420,19 @@ for num_event in range(num_events):
         # Use SNR here or NewSNR, or other??
         loudest_idx = hd_sngl.snr.argmax()
         hd_sngl.apply_mask([loudest_idx])
+        ifo_tids_strings += ['%s:%s' % (curr_ifo, loudest_idx)]
+    curr_tags = ['THA_TRIGS']
+    curr_tags += [str(num_event)]
 
-        # What are the parameters of this trigger?
-        curr_params = copy.deepcopy(inj_params)
-        curr_params['mass1'] = hd_sngl.mass1[0]
-        curr_params['mass2'] = hd_sngl.mass2[0]
-        curr_params['spin1z'] = hd_sngl.spin1z[0]
-        curr_params['spin2z'] = hd_sngl.spin2z[0]
-        curr_params['f_lower'] = hd_sngl.f_lower[0]
-        # don't require precessing template info if not present
-        try:
-            curr_params['spin1x'] = hd_sngl.spin1x[0]
-            curr_params['spin2x'] = hd_sngl.spin2x[0]
-            curr_params['spin1y'] = hd_sngl.spin1y[0]
-            curr_params['spin2y'] = hd_sngl.spin2y[0]
-            curr_params['inclination'] = hd_sngl.inclination[0]
-        except KeyError:
-            pass
-        try:
-            # Only present for precessing search
-            curr_params['u_vals'] = hd_sngl.u_vals[0]
-        except:
-            pass
-
-        curr_tags = ['TMPLT_PARAMS_%s' %(curr_ifo,)]
-        curr_tags += [str(num_event)]
-        _, loudest_plot = mini.make_single_template_plots(workflow, insp_segs,
+    _, loudest_plot = mini.make_single_template_plots(workflow, insp_segs,
+                                single_triggers,
+                                tmpltbank_file,
                                 args.inspiral_data_read_name,
-                                args.inspiral_data_analyzed_name, curr_params,
+                                args.inspiral_data_analyzed_name, inj_params,
                                 args.output_dir, inj_file=injection_xml_file,
-                                tags=args.tags + curr_tags,
-                                params_str='loudest template in %s' % curr_ifo )
-        files += loudest_plot
+                                special_tids=' '.join(ifo_tids_strings),
+                                tags=args.tags + curr_tags)
+    files += loudest_plot
 
     layouts += list(layout.grouper(files, 2))
 

--- a/bin/minifollowups/pycbc_plot_harmonic_waveform
+++ b/bin/minifollowups/pycbc_plot_harmonic_waveform
@@ -28,6 +28,7 @@ import numpy
 from pycbc import init_logging, add_common_pycbc_options
 import pycbc.results
 from pycbc.types import MultiDetOptionAction
+from pycbc.types import FrequencySeries
 from pycbc.events import ranking
 from pycbc.filter.matchedfilter import sigma
 from pycbc.io import HFile, SingleDetTriggers
@@ -80,8 +81,40 @@ def obtain_trigger_amp_phase(trigs, special_idx):
         phases_dict[i] = trigs.trigs[phase_key][special_idx]
     return amplitudes_dict, phases_dict
 
-def compute_harmonic_waveform(trigs, special_idx):
+def compute_harmonic_waveform(trigs, special_idx, ifo, merge_psd_file):
     bad_tempid = trigs.trigs['template_id'][special_idx]
+    end_time = trigs.trigs['end_time'][special_idx]
+
+    psd_fp = h5py.File(merge_psd_file, 'r')
+    psd_fp = psd_fp[ifo]
+    psd_idx = None
+    for idx in range(len(psd_fp['start_time'])):
+        st = psd_fp['start_time'][idx]
+        et = psd_fp['end_time'][idx]
+        if st < end_time < et:
+            print(st, et, end_time)
+            if psd_idx is not None:
+                # This may very well happen and we need to decide on which PSD
+                err_msg = "There seems to be multiple PSDs covering this time."
+                err_msg += " I don't know which one to use! Taking first."
+                logging.warn(err_msg)
+            else:
+                psd_idx = idx
+    if psd_idx is None:
+        err_msg = "I couldn't find an overlapping PSD in the file!"
+        err_msg += f" Covering time {end_time}."
+
+    psd_data = psd_fp[f'psds/{psd_idx}']
+    df = psd_data.attrs['delta_f']
+    epoch = psd_data.attrs['epoch']
+    data = psd_data[:]
+    psd = FrequencySeries(
+        data,
+        delta_f=df,
+        epoch=epoch,
+        dtype=data.dtype,
+        copy=False
+    )
     
     amplitudes_dict, phases_dict = obtain_trigger_amp_phase(trigs, special_idx)
 
@@ -91,25 +124,30 @@ def compute_harmonic_waveform(trigs, special_idx):
     sample_freq = 32.0
     f_lower = 30.0
     flen = int(sample_rate * sample_freq/2+1)
+    ncomp = trigs.bank['num_comps'][bad_tempid]
+    # Hardcoded max numcomps for now:
+    if ncomp > 3:
+        ncomp = 3
 
     phenom_object = PhenomXPTemplate(params, sample_rate, f_lower)
 
-    harmonics = phenom_object.compute_waveform_five_comps(1.0/sample_freq, 1024.0, num_comps = 5)
+    harmonics = phenom_object.get_whitened_normalized_comps(
+        1.0/sample_freq,
+        psd,
+        num_comps=ncomp,
+    )
 
-    ncomp = trigs.bank['num_comps'][bad_tempid]
-    reverse_flag = trigs.bank['reverse_flag'][bad_tempid]
+    #reverse_flag = trigs.bank['reverse_flag'][bad_tempid]
     logging.info("Template id: {}, mass1: {}, mass2: {}, SNR: {}, ncomp: {}".format(bad_tempid, 
                                                                         trigs.bank['mass1'][bad_tempid],
                                                                         trigs.bank['mass2'][bad_tempid],
                                                                         trigs.trigs['snr'][special_idx],
                                                                         ncomp) )
 
+    # FIXME: Can we remove harmonics_dict and just use harmonics?
     harmonics_dict = {}
     for i in range(ncomp):
-        if reverse_flag == 1:
-            harmonics_dict[i] = harmonics[4-i]
-        else: 
-            harmonics_dict[i] = harmonics[i]
+        harmonics_dict[i] = harmonics[i]
 
     p_det = _make_waveform_from_precessing_harmonics(phenom_object, harmonics_dict, amplitudes_dict, phases_dict)
 
@@ -121,7 +159,15 @@ def compute_harmonic_waveform(trigs, special_idx):
     #Amplify the template
     amp_factor = sigma(harmonics_dict[0], low_frequency_cutoff=f_lower)
     shifted_t /= amp_factor
-    return shifted_t, ncomp
+
+    harmonics = []
+    for i in range(ncomp):
+        harm_temp = harmonics_dict[i].to_timeseries()
+        harm_temp = harm_temp.cyclic_time_shift(10)
+        harm_temp /= amp_factor
+        harmonics.append(harm_temp)
+
+    return shifted_t, ncomp, harmonics
     
 
 parser = argparse.ArgumentParser()
@@ -129,18 +175,25 @@ add_common_pycbc_options(parser)
 #parser.add_argument('--verbose')
 parser.add_argument('--single-trigger-files', nargs='+',
     action=MultiDetOptionAction, metavar="IFO:FILE",
+    required=True,
     help="The HDF format single detector merged trigger files, in "
          "multi-ifo argument format, H1:file1.hdf L1:file2.hdf, etc")
-parser.add_argument('--bank-file', 
+parser.add_argument('--bank-file',
+    required=True,
     help="The bank file in HDF format")
 parser.add_argument('--veto-file',
-    help="The bank file in XML format")
+    help="The veto file in XML format")
 parser.add_argument('--special-trigger-ids', nargs='+', type=int,
     action=MultiDetOptionAction, metavar="IFO:trigger_id",required=True,
     help="The set of special trigger ids to plot a star at")
 parser.add_argument('--plot-type',
     choices=ranking.sngls_ranking_function_dict, default='snr',
     help="Which single-detector ranking statistic to plot.")
+parser.add_argument('--merge-psd-files', nargs='+',
+    action=MultiDetOptionAction, metavar="IFO:FILE",
+    help="Location of the MERGE_PSD output fiel to get the PSD from.",
+    required=True,
+)
 parser.add_argument('--output-file')
 
 args = parser.parse_args()
@@ -150,7 +203,9 @@ fig = pylab.figure()
 
 bankf = h5py.File(args.bank_file, 'r')
 
-fig, axs = pylab.subplots(2,1, figsize=(14,8))
+fig, axs = pylab.subplots(len(args.single_trigger_files), 1, figsize=(14,8))
+if len(args.single_trigger_files) == 1:
+    axs = [axs]
 axs_count=0
 
 for ifo in args.single_trigger_files.keys():
@@ -168,17 +223,23 @@ for ifo in args.single_trigger_files.keys():
     
     params = template_params(bankf, trigs.trigs['template_id'][special_idx])
 
-    shifted_t, ncomp = compute_harmonic_waveform(trigs, special_idx)
+    shifted_t, ncomp, harmonics = compute_harmonic_waveform(trigs, special_idx, ifo, args.merge_psd_files[ifo])
 
     ###Zoom-in automatically. Again a crappy way! Improve it !!
     threshold = 1e-2  # or something data-specific
     nonzero_indices = numpy.where(numpy.abs(shifted_t) > threshold)[0]
     i_min, i_max = nonzero_indices[0], nonzero_indices[-1]
 
-    axs[axs_count].plot(shifted_t.sample_times[i_min:i_max], shifted_t[i_min:i_max])
+    axs[axs_count].plot(shifted_t.sample_times[i_min:i_max], shifted_t[i_min:i_max], label="Full waveform")
+    for idx, harm in enumerate(harmonics):
+        axs[axs_count].plot(harm.sample_times[i_min:i_max], harm[i_min:i_max], linestyle=':', label=f"Harmonic {idx+1}")
     axs[axs_count].set_title('{}: {}-harmonic plot'.format(ifo, ncomp))
     axs[axs_count].set_xlabel('time (s)')
     axs[axs_count].set_ylabel("Scaled $h(t)$")
+    max_val = abs(shifted_t.data).argmax()
+    max_time = shifted_t.sample_times[max_val]
+    axs[axs_count].set_xlim([max_time-0.7, max_time+0.2])
+    axs[axs_count].legend()
     axs[axs_count].grid()
     axs_count += 1
 

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -42,6 +42,8 @@ parser.add_argument('--bank-file',
                     help="HDF format template bank file")
 parser.add_argument('--single-detector-file',
                     help="HDF format merged single detector trigger files")
+parser.add_argument('--psd-file',
+                    help='Merged PSD file')
 parser.add_argument('--instrument', help="Name of interferometer e.g. H1")
 parser.add_argument('--foreground-censor-file',
                     help="The censor file to be used if vetoing triggers "
@@ -110,6 +112,11 @@ layouts = []
 tmpltbank_file = resolve_url_to_file(os.path.abspath(args.bank_file))
 sngl_file = resolve_url_to_file(
     os.path.abspath(args.single_detector_file),
+    attrs={'ifos': args.instrument}
+)
+
+psd_file = resolve_url_to_file(
+    os.path.abspath(args.psd_file),
     attrs={'ifos': args.instrument}
 )
 
@@ -272,44 +279,24 @@ for rank, num_event in enumerate(order):
                               tags=args.tags + [str(rank)])
 
     files += mini.make_harmonic_waveform(workflow, [sngl_file], tmpltbank_file,
+                              [psd_file],
                               args.output_dir, veto_file=veto_file, special_tids=ifo_tid,
                               tags=args.tags + [str(rank)])
     curr_params = {}
-    curr_params['mass1'] = trigs.mass1[num_event]
-    curr_params['mass2'] = trigs.mass2[num_event]
-    curr_params['spin1z'] = trigs.spin1z[num_event]
-    curr_params['spin2z'] = trigs.spin2z[num_event]
-    curr_params['f_lower'] = trigs.f_lower[num_event]
     curr_params[args.instrument + '_end_time'] = time
     curr_params['mean_time'] = time
-    # don't require precessing template info if not present
-    try:
-        curr_params['spin1x'] = trigs.spin1x[num_event]
-        curr_params['spin2x'] = trigs.spin2x[num_event]
-        curr_params['spin1y'] = trigs.spin1y[num_event]
-        curr_params['spin2y'] = trigs.spin2y[num_event]
-        curr_params['inclination'] = trigs.inclination[num_event]
-    except KeyError:
-        pass
-    try:
-        # Only present for precessing search
-        curr_params['u_vals'] = trigs.u_vals[num_event]
-    except:
-        pass
 
     _, sngl_plot = mini.make_single_template_plots(workflow, insp_segs,
+                            [sngl_file], tmpltbank_file,
                             args.inspiral_data_read_name,
                             args.inspiral_data_analyzed_name,
                             curr_params,
                             args.output_dir,
+                            special_tids=ifo_tid,
                             data_segments={args.instrument : insp_data_seglists},
                             tags=args.tags+[str(rank)])
 
     files += sngl_plot
-
-    files += mini.make_plot_waveform_plot(workflow, curr_params,
-                                        args.output_dir, [args.instrument],
-                                        tags=args.tags + [str(rank)])
 
     files += mini.make_singles_timefreq(workflow, sngl_file, tmpltbank_file,
                             time, args.output_dir,

--- a/bin/minifollowups/pycbc_sngl_minifollowup
+++ b/bin/minifollowups/pycbc_sngl_minifollowup
@@ -308,10 +308,6 @@ for rank, num_event in enumerate(order):
                                   data_segments=insp_data_seglists,
                                   tags=args.tags + [str(rank)])
    
-    #files += mini.make_harmonic_waveform(workflow, args.output_dir, [sngl_file], tmpltbank_file,
-    #                          veto_file=veto_file, special_tids=ifo_tid,
-    #                          tags=args.tags + [str(rank)])
-
     layouts += list(layout.grouper(files, 2))
 
 workflow.save()

--- a/bin/pycbc_single_template
+++ b/bin/pycbc_single_template
@@ -21,10 +21,11 @@ import sys
 import logging
 import argparse
 import numpy
+import h5py
 
 import pycbc
 from pycbc import vetoes, psd, waveform, strain, scheme, fft, filter
-from pycbc.io import WaveformArray, HFile
+from pycbc.io import WaveformArray, HFile, SingleDetTriggers
 from pycbc import events
 from pycbc.filter import resample_to_delta_t
 from pycbc.types import zeros, complex64
@@ -175,6 +176,17 @@ parser.add_argument("--data-read-name",
 parser.add_argument("--data-analyzed-name",
         help="name of the segmentlist containing the data analysed by each job "
              "from the inspiral segment file")
+# Parameters for THA triggers
+parser.add_argument("--use-tha-trigger-as-template", action="store_true",
+                  default=False,
+                  help="If given, use THA trigger as template")
+parser.add_argument('--single-trigger-file',
+    help="The bank file in HDF format")
+parser.add_argument('--bank-file',
+    help="The bank file in HDF format")
+parser.add_argument('--special-trigger-id', type=int,
+    help="The bank file in HDF format")
+
 
 # Add options groups
 psd.insert_psd_option_group(parser)
@@ -301,6 +313,68 @@ with ctx:
             approximant = inj.approximant
         template = waveform.td_waveform_to_fd_waveform(td_template, length=flen)
         template = template.astype(complex_same_precision_as(segments[0]))
+    elif opt.use_tha_trigger_as_template:
+        # Probably shouldn't be segments[0]
+        stilde = segments[0]
+        from pycbc.waveform.bank import PhenomXPTemplate
+        # Generating template from trigger list
+        trigs = SingleDetTriggers(
+            opt.single_trigger_file,
+            ifo,
+            bank_file=opt.bank_file,
+        )
+        special_idx = opt.special_trigger_id
+        norm_snr = 0.0
+        #Get the total SNR
+        for i in range(5):
+            key = 'snr_comp_{}'.format(i+1)
+            norm_snr += trigs.trigs[key][special_idx]**2
+        norm_snr = numpy.sqrt(norm_snr)
+
+        amplitudes_dict = {}
+        phases_dict = {}
+
+        for i in range(5):
+            key = 'snr_comp_{}'.format(i+1)
+            phase_key = 'coa_phase_comp_{}'.format(i+1)
+            amplitudes_dict[i] = trigs.trigs[key][special_idx]/norm_snr
+            phases_dict[i] = trigs.trigs[phase_key][special_idx]
+
+        bad_tempid = trigs.trigs['template_id'][special_idx]
+        ncomp = trigs.bank['num_comps'][bad_tempid]
+        # FIXME: Harcoding max num_comps for now
+        if ncomp > 3:
+            ncomp = 3
+
+        class template_params:
+            def __init__(self, bank, x):
+                for key in bank.keys():
+                    setattr(self, key, bank[key][x])
+
+        params = template_params(h5py.File(opt.bank_file), trigs.trigs['template_id'][special_idx])
+
+        phenom_object = PhenomXPTemplate(params, opt.sample_rate, opt.low_frequency_cutoff)
+
+        harmonics = phenom_object.get_whitened_normalized_comps(
+            1.0/opt.segment_length,
+            stilde.psd,
+            num_comps=ncomp,
+        )
+
+        template = None
+        for harm_idx, harm in enumerate(harmonics):
+            if harm_idx == ncomp:
+                break
+            if template is not None:
+                template += amplitudes_dict[harm_idx] * harm * numpy.exp(1j * phases_dict[harm_idx])
+            else:
+                template = amplitudes_dict[harm_idx] * harm * numpy.exp(1j * phases_dict[harm_idx])
+
+        # Don't want whitened template
+        template = template * (stilde.psd.data[:]**0.5)
+        template = template.astype(complex_same_precision_as(segments[0]))
+        approximant = 'THAWaveform'
+
     else:
         approximant = waveform.bank.parse_approximant_arg(opt.approximant, row)[0]
         logging.info("Making template: %s", opt.approximant)

--- a/bin/workflows/pycbc_make_offline_search_workflow
+++ b/bin/workflows/pycbc_make_offline_search_workflow
@@ -530,6 +530,11 @@ for insp_file in full_insps:
 
 for insp_file in full_insps:
     curr_ifo = insp_file.ifo
+    for psd_file in psd_files:
+        if psd_file.ifo == insp_file.ifo:
+            break
+    else:
+        raise ValueError()
     for subsec in workflow.cp.get_subsections('workflow-sngl_minifollowups'):
         if subsec in excl_subsecs:
             continue
@@ -537,7 +542,7 @@ for insp_file in full_insps:
         dir_str = workflow.cp.get(sec_name, 'section-header')
         currdir = rdir['single_triggers/{}_{}'.format(curr_ifo, dir_str)]
         wf.setup_single_det_minifollowups\
-            (workflow, insp_file, hdfbank, insp_files_seg_file,
+            (workflow, insp_file, hdfbank, psd_file, insp_files_seg_file,
              data_analysed_name, trig_generated_name, 'daxes', currdir,
              statfiles=wf.FileList(statfiles),
              fg_file=censored_veto, fg_name='closed_box',
@@ -587,13 +592,15 @@ layout.two_column_layout(rdir['open_box_result'], main_page)
 mfup_dir_fg = rdir['open_box_result/loudest_events_followup']
 mfup_dir_bg = rdir['background_triggers/loudest_background_followup']
 wf.setup_foreground_minifollowups(workflow, combined_bg_file,
-                                  full_insps, hdfbank, insp_files_seg_file,
+                                  full_insps, hdfbank, psd_files,
+                                  insp_files_seg_file,
                                   data_analysed_name, trig_generated_name,
                                   'daxes', mfup_dir_fg,
                                   tags=combined_bg_file.tags + ['foreground'])
 
 wf.setup_foreground_minifollowups(workflow, combined_bg_file,
-                                  full_insps, hdfbank, insp_files_seg_file,
+                                  full_insps, hdfbank, psd_files,
+                                  insp_files_seg_file,
                                   data_analysed_name, trig_generated_name,
                                   'daxes', mfup_dir_bg,
                                   tags=combined_bg_file.tags + ['background'])
@@ -853,7 +860,8 @@ for inj_file, tag in zip(inj_files, inj_tags):
         curr_dir_nam += '_' + suf_str
     currdir = rdir[curr_dir_nam]
     wf.setup_injection_minifollowups(workflow, found_inj, inj_file,
-                                     insps, hdfbank, insp_files_seg_file,
+                                     insps, hdfbank, psd_files,
+                                     insp_files_seg_file,
                                      data_analysed_name, trig_generated_name,
                                      'daxes', currdir, tags=[tag])
 

--- a/pycbc/workflow/minifollowups.py
+++ b/pycbc/workflow/minifollowups.py
@@ -531,7 +531,7 @@ def make_single_template_files(workflow, segs, singles, bank_file, ifo,
     return node.output_files
 
 
-def make_harmonic_waveform(workflow, singles, bank_file, psd_file,  out_dir,
+def make_harmonic_waveform(workflow, singles, bank_file, psd_files,  out_dir,
                            veto_file=None, special_tids=None,
                            tags=None):
     tags = [] if tags is None else tags
@@ -541,7 +541,7 @@ def make_harmonic_waveform(workflow, singles, bank_file, psd_file,  out_dir,
     node = PlotExecutable(workflow.cp, name, ifos=workflow.ifos,
                           out_dir=out_dir, tags=tags).create_node()
     node.add_multiifo_input_list_opt('--single-trigger-files', singles)
-    node.add_multiifo_input_list_opt('--merge-psd-files', psd_file)
+    node.add_multiifo_input_list_opt('--merge-psd-files', psd_files)
     node.add_input_opt('--bank-file', bank_file)
     if veto_file is not None:
         node.add_input_opt('--veto-file', veto_file)


### PR DESCRIPTION
@rahuldhurkunde 

Here is a patch for fixing the harmonic waveform plot as we discussed and making the single template plots work for THA runs. An example output is here:

https://ldas-jobs.ligo.caltech.edu/~ian.harry/aLIGO/O4/dev/bbh_prec_testing/chunk_sgchisq_one_day_run_8

I'm still working on this because I'd like to add the harmonic_waveform_plot for the foreground_minifollowup ... But everything else should be visible on the web page if you have questions/comments.

(Some of the single_inspiral jobs don't agree because I changed the resample method to something faster to get jobs through quicker. This meant some things got auto-gated that weren't before. I'll roll this back when rerunning, but it's an interesting observation).