### PR TITLE
FIx time offset in Phenom waveforms

### DIFF
--- a/bin/minifollowups/pycbc_plot_harmonic_waveform
+++ b/bin/minifollowups/pycbc_plot_harmonic_waveform
@@ -151,8 +151,7 @@ def compute_harmonic_waveform(trigs, special_idx, ifo, merge_psd_file):
 
     p_det = _make_waveform_from_precessing_harmonics(phenom_object, harmonics_dict, amplitudes_dict, phases_dict)
 
-    #Time-shift needed to wrap around the IFFT
-    ####Hard-coded to 10, need to change this
+    # Apply 2s time-shift to wrap the merger away from the endfor plotting
     pt_det = p_det.to_timeseries()
     shifted_t = pt_det.cyclic_time_shift(-2)
 

--- a/bin/minifollowups/pycbc_plot_harmonic_waveform
+++ b/bin/minifollowups/pycbc_plot_harmonic_waveform
@@ -154,7 +154,7 @@ def compute_harmonic_waveform(trigs, special_idx, ifo, merge_psd_file):
     #Time-shift needed to wrap around the IFFT
     ####Hard-coded to 10, need to change this
     pt_det = p_det.to_timeseries()
-    shifted_t = pt_det.cyclic_time_shift(10)
+    shifted_t = pt_det.cyclic_time_shift(-2)
 
     #Amplify the template
     amp_factor = sigma(harmonics_dict[0], low_frequency_cutoff=f_lower)
@@ -163,7 +163,7 @@ def compute_harmonic_waveform(trigs, special_idx, ifo, merge_psd_file):
     harmonics = []
     for i in range(ncomp):
         harm_temp = harmonics_dict[i].to_timeseries()
-        harm_temp = harm_temp.cyclic_time_shift(10)
+        harm_temp = harm_temp.cyclic_time_shift(-2)
         harm_temp /= amp_factor
         harmonics.append(harm_temp)
 
@@ -238,7 +238,7 @@ for ifo in args.single_trigger_files.keys():
     axs[axs_count].set_ylabel("Scaled $h(t)$")
     max_val = abs(shifted_t.data).argmax()
     max_time = shifted_t.sample_times[max_val]
-    axs[axs_count].set_xlim([max_time-0.7, max_time+0.2])
+    axs[axs_count].set_xlim([-0.7, 0.2])
     axs[axs_count].legend()
     axs[axs_count].grid()
     axs_count += 1

--- a/pycbc/workflow/pegasus_sites.py
+++ b/pycbc/workflow/pegasus_sites.py
@@ -241,7 +241,7 @@ def add_osg_site(sitecat, cp):
     site.add_profiles(Namespace.CONDOR, key="Requirements",
                       value="(HAS_SINGULARITY =?= TRUE) && "
                             "(IS_GLIDEIN =?= True)")
-    cvmfs_loc = '"./tha_precession_v1_3.sif"'
+    cvmfs_loc = '"./tha_precession_v1_4.sif"'
     site.add_profiles(Namespace.CONDOR, key="My.SingularityImage",
                       value=cvmfs_loc)
     site.add_profiles(Namespace.CONDOR, key='transfer_input_files',


### PR DESCRIPTION
PhenomXP waveforms do not follow expected conventions for FD waveforms. This corrects for an epoch offset that shouldn't be there. I think this bug makes the sgchisq less effective, so I'm hoping fixing it will improve that ... Not relevant for any of the NSBH results, other than all the end times are offset by a tenth of a second (which probably showed up in PE results) ... Actually the offset is probably smaller for NSBH because faster ringdown.

@rahuldhurkunde @hoyc1 