### PR TITLE
Remove unnecessary square root

### DIFF
--- a/bin/pycbc_inspiral_tha
+++ b/bin/pycbc_inspiral_tha
@@ -107,45 +107,45 @@ parser.add_argument("--chisq-bins", default=0, help=
 parser.add_argument("--chisq-threshold", type=float, default=0,
                     help="FIXME: ADD")
 parser.add_argument("--chisq-delta", type=float, default=0, help="FIXME: ADD")
-parser.add_argument("--autochi-number-points", type=int, default=0,
-                    help="The number of points to use, in both directions if"
-                         "doing a two-sided auto-chisq, to calculate the"
-                         "auto-chisq statistic.")
-parser.add_argument("--autochi-stride", type=int, default=0,
-                    help="The gap, in sample points, between the points at"
-                         "which to calculate auto-chisq.")
-parser.add_argument("--autochi-two-phase", action="store_true",
-                    default=False,
-                    help="If given auto-chisq will be calculated by testing "
-                         "against both phases of the SNR time-series. "
-                         "If not given, only the phase matching the trigger "
-                         "will be used.")
-parser.add_argument("--autochi-onesided", action='store', default=None,
-                    choices=['left','right'],
-                    help="Decide whether to calculate auto-chisq using"
-                         "points on both sides of the trigger or only on one"
-                         "side. If not given points on both sides will be"
-                         "used. If given, with either 'left' or 'right',"
-                         "only points on that side (right = forward in time,"
-                         "left = back in time) will be used.")
-parser.add_argument("--autochi-reverse-template", action="store_true",
-                    default=False,
-                    help="If given, time-reverse the template before"
-                         "calculating the auto-chisq statistic. This will"
-                         "come at additional computational cost as the SNR"
-                         "time-series will need recomputing for the time-"
-                         "reversed template.")
-parser.add_argument("--autochi-max-valued", action="store_true",
-                    default=False,
-                    help="If given, store only the maximum value of the auto-"
-                         "chisq over all points tested. A disadvantage of this "
-                         "is that the mean value will not be known "
-                         "analytically.")
-parser.add_argument("--autochi-max-valued-dof", action="store", metavar="INT",
-                    type=int,
-                    help="If using --autochi-max-valued this value denotes "
-                         "the pre-calculated mean value that will be stored "
-                         "as the auto-chisq degrees-of-freedom value.")
+#parser.add_argument("--autochi-number-points", type=int, default=0,
+#                    help="The number of points to use, in both directions if"
+#                         "doing a two-sided auto-chisq, to calculate the"
+#                         "auto-chisq statistic.")
+#parser.add_argument("--autochi-stride", type=int, default=0,
+#                    help="The gap, in sample points, between the points at"
+#                         "which to calculate auto-chisq.")
+#parser.add_argument("--autochi-two-phase", action="store_true",
+#                    default=False,
+#                    help="If given auto-chisq will be calculated by testing "
+#                         "against both phases of the SNR time-series. "
+#                         "If not given, only the phase matching the trigger "
+#                         "will be used.")
+#parser.add_argument("--autochi-onesided", action='store', default=None,
+#                    choices=['left','right'],
+#                    help="Decide whether to calculate auto-chisq using"
+#                         "points on both sides of the trigger or only on one"
+#                         "side. If not given points on both sides will be"
+#                         "used. If given, with either 'left' or 'right',"
+#                         "only points on that side (right = forward in time,"
+#                         "left = back in time) will be used.")
+#parser.add_argument("--autochi-reverse-template", action="store_true",
+#                    default=False,
+#                    help="If given, time-reverse the template before"
+#                         "calculating the auto-chisq statistic. This will"
+#                         "come at additional computational cost as the SNR"
+#                         "time-series will need recomputing for the time-"
+#                         "reversed template.")
+#parser.add_argument("--autochi-max-valued", action="store_true",
+#                    default=False,
+#                    help="If given, store only the maximum value of the auto-"
+#                         "chisq over all points tested. A disadvantage of this "
+#                         "is that the mean value will not be known "
+#                         "analytically.")
+#parser.add_argument("--autochi-max-valued-dof", action="store", metavar="INT",
+#                    type=int,
+#                    help="If using --autochi-max-valued this value denotes "
+#                         "the pre-calculated mean value that will be stored "
+#                         "as the auto-chisq degrees-of-freedom value.")
 parser.add_argument("--downsample-factor", type=int,
                     help="Factor that determines the interval between the "
                          "initial SNR sampling. If not set (or 1) no sparse sample "
@@ -257,24 +257,24 @@ def template_triggers(t_num):
                      (t_num + 1, len(bank), s_num + 1, len(segments)))
 
         sigmasq = 1.
-        snr_full, norm, corrs, snrs, idx, snrv_full = \
+        snrsq_full, norm, corrs, snrs, idx, snrv_full = \
            matched_filter.matched_filter_and_cluster(s_num,
                                                      sigmasq,
                                                      cluster_window,
                                                      epoch=stilde._epoch,
                                                      num_comps=num_comps)
+        if not len(idx):
+            continue
         if inj_filter_rejector.enabled:
             trig_times = (
                 (idx + stilde.cumulative_index) /
-                snr_full.sample_rate + opt.gps_start_time
+                snrsq_full.sample_rate + opt.gps_start_time
             )
             inj_idxs = inj_filter_rejector.find_indices_in_injection_intervals(
                 trig_times
             )
             idx = idx[inj_idxs]
             snrv_full = snrv_full[inj_idxs]
-        if not len(idx):
-            continue
 
         out_vals = out_vals_ref.copy()
         out_vals['bank_chisq'], out_vals['bank_chisq_dof'] = \
@@ -295,11 +295,11 @@ def template_triggers(t_num):
             idx+stilde.analyze.start
         )
 
-        out_vals['cont_chisq'], _ = \
-              autochisq.values(snr_full, idx+stilde.analyze.start,
-                               template_comps[0],
-                               stilde.psd, norm, stilde=stilde,
-                               low_frequency_cutoff=flow)
+        #out_vals['cont_chisq'], _ = \
+        #      autochisq.values(snr_full, idx+stilde.analyze.start,
+        #                       template_comps[0],
+        #                       stilde.psd, norm, stilde=stilde,
+        #                       low_frequency_cutoff=flow)
 
         out_vals['snr'] = snrv_full * norm
         for i, snr_comp in enumerate(snrs):
@@ -362,7 +362,6 @@ with ctx:
         'chisq_dof'      : int,
         'bank_chisq'     : float32,
         'bank_chisq_dof' : int,
-        'cont_chisq'     : float32,
         'psd_var_val'    : float32,
         'sigmasq'        : float32,
                 }
@@ -451,13 +450,13 @@ with ctx:
         snr_threshold=opt.chisq_snr_threshold
     )
 
-    autochisq = vetoes.SingleDetAutoChisq(opt.autochi_stride,
-                                 opt.autochi_number_points,
-                                 onesided=opt.autochi_onesided,
-                                 twophase=opt.autochi_two_phase,
-                                 reverse_template=opt.autochi_reverse_template,
-                                 take_maximum_value=opt.autochi_max_valued,
-                                 maximal_value_dof=opt.autochi_max_valued_dof)
+    #autochisq = vetoes.SingleDetAutoChisq(opt.autochi_stride,
+    #                             opt.autochi_number_points,
+    #                             onesided=opt.autochi_onesided,
+    #                             twophase=opt.autochi_two_phase,
+    #                             reverse_template=opt.autochi_reverse_template,
+    #                             take_maximum_value=opt.autochi_max_valued,
+    #                             maximal_value_dof=opt.autochi_max_valued_dof)
 
     logging.info("Whitening frequency-domain data segments")
     for seg in segments:


### PR DESCRIPTION
@rahuldhurkunde Here's one more optimization in the precessing code. There's a `sqrt()` operation being performed on the SNR array (every time), that isn't needed. We never use the (full) SNR array unless we are doing autochisq.

So I disabled autochisq because we don't use it (if we wanted to re-enable it, it could take the SNR**2 timeseries and do the square root in the necessary interval(s) ... But I don't know that we want/need autochisq).

I also moved one small block to a function, as profiling Cython commands is difficult, so having a function call which *only* calls a Cython code makes it easier to see what is going on ... I may do more of this, but that won't affect efficiency.