### PR TITLE
L3 cache memory check in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,9 @@ RUN pip install git+https://github.com/icg-gravwaves/pycbc.git@tha_development_w
 # Add post-install script
 ADD docker/etc/docker-install.sh /etc/docker-install.sh
 
-# Set the default command to start a login shell for the pycbc user
-# The default command is now simpler as we are already the correct user
-CMD ["/bin/bash", "-l", "pycbc"]
+# When the container is started with
+#   docker run -it pycbc/pycbc-el8:latest
+# the default is to start a loging shell as the pycbc user.
+# This can be overridden to log in as root with
+#   docker run -it pycbc/pycbc-el8:latest /bin/bash -l
+CMD ["/bin/su", "-l", "pycbc"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,9 @@ ADD docker/etc/cvmfs/default.local /etc/cvmfs/default.local
 ADD docker/etc/cvmfs/60-osg.conf /etc/cvmfs/60-osg.conf
 ADD docker/etc/cvmfs/config-osg.opensciencegrid.org.conf /etc/cvmfs/config-osg.opensciencegrid.org.conf
 
-# --- SOLUTION PART 1: Create the getconf wrapper script ---
-# This command creates the wrapper script inside the image.
+# LEVEL3_CACHE memory checks could returns undefined
+# Assigning values to the environment variable does not work.
+# So we need a wrapper script inside the image.
 # It intercepts calls for LEVEL3_CACHE_SIZE and returns a default value.
 RUN echo '#!/bin/sh' > /usr/local/bin/getconf && \
     echo 'if [ "$1" = "LEVEL3_CACHE_SIZE" ]; then' >> /usr/local/bin/getconf && \
@@ -20,8 +21,7 @@ RUN echo '#!/bin/sh' > /usr/local/bin/getconf && \
     echo '  exec /usr/bin/getconf "$@"' >> /usr/local/bin/getconf && \
     echo 'fi' >> /usr/local/bin/getconf
 
-# --- SOLUTION PART 2: Make the wrapper executable ---
-# This must be done as root before switching user.
+# Make the wrapper executable
 RUN chmod +x /usr/local/bin/getconf
 
 # Set up extra repositories

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,24 @@ ADD docker/etc/cvmfs/default.local /etc/cvmfs/default.local
 ADD docker/etc/cvmfs/60-osg.conf /etc/cvmfs/60-osg.conf
 ADD docker/etc/cvmfs/config-osg.opensciencegrid.org.conf /etc/cvmfs/config-osg.opensciencegrid.org.conf
 
+# --- SOLUTION PART 1: Create the getconf wrapper script ---
+# This command creates the wrapper script inside the image.
+# It intercepts calls for LEVEL3_CACHE_SIZE and returns a default value.
+RUN echo '#!/bin/sh' > /usr/local/bin/getconf && \
+    echo 'if [ "$1" = "LEVEL3_CACHE_SIZE" ]; then' >> /usr/local/bin/getconf && \
+    echo '  echo "8388608"' >> /usr/local/bin/getconf && \
+    echo 'elif [ "$1" = "LEVEL3_CACHE_ASSOC" ]; then' >> /usr/local/bin/getconf && \
+    echo '  echo "8"' >> /usr/local/bin/getconf && \
+    echo 'elif [ "$1" = "LEVEL3_CACHE_LINESIZE" ]; then' >> /usr/local/bin/getconf && \
+    echo '  echo "64"' >> /usr/local/bin/getconf && \
+    echo 'else' >> /usr/local/bin/getconf && \
+    echo '  exec /usr/bin/getconf "$@"' >> /usr/local/bin/getconf && \
+    echo 'fi' >> /usr/local/bin/getconf
+
+# --- SOLUTION PART 2: Make the wrapper executable ---
+# This must be done as root before switching user.
+RUN chmod +x /usr/local/bin/getconf
+
 # Set up extra repositories
 RUN dnf -y install --setopt=install_weak_deps=False https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm && dnf -y install --setopt=install_weak_deps=False cvmfs cvmfs-config-default && dnf clean all && dnf makecache && dnf -y install python39 python39-devel && dnf -y install --setopt=install_weak_deps=False fftw-libs-single fftw-devel fftw fftw-libs-long fftw-libs fftw-libs-double gsl gsl-devel hdf5 hdf5-devel osg-ca-certs git gcc-c++ && python3.9 -m pip install --no-cache-dir --upgrade pip setuptools wheel cython && python3.9 -m pip install --no-cache-dir mkl ipython lalsuite && \
     dnf -y install --setopt=install_weak_deps=False https://repo.opensciencegrid.org/osg/3.5/el8/testing/x86_64/osg-wn-client-3.5-5.osg35.el8.noarch.rpm && dnf -y install --setopt=install_weak_deps=False pelican-osdf-compat-7.10.11-1.x86_64 && dnf -y install --setopt=install_weak_deps=False pelican-7.10.11-1.x86_64 && dnf clean all
@@ -42,14 +60,15 @@ ADD requirements-igwn.txt /etc/requirements-igwn.txt
 
 ADD companion.txt /etc/companion.txt
 
-# Replace the github repo accordingly
-RUN /bin/sh -c pip install -r /etc/requirements.txt && pip install gwpy>=0.8.1  && pip install git+https://github.com/icg-gravwaves/pycbc.git@tha_development_work
+# Step 1: Install dependencies into the local site-packages
+RUN python3.9 -m pip install -r /etc/requirements.txt
 
+# Step 2: Install the pycbc branch from git
+RUN pip install git+https://github.com/icg-gravwaves/pycbc.git@tha_development_work
+
+# Add post-install script
 ADD docker/etc/docker-install.sh /etc/docker-install.sh
 
-# When the container is started with
-#   docker run -it pycbc/pycbc-el8:latest
-# the default is to start a loging shell as the pycbc user.
-# This can be overridden to log in as root with
-#   docker run -it pycbc/pycbc-el8:latest /bin/bash -l
-CMD ["/bin/su", "-l", "pycbc"]
+# Set the default command to start a login shell for the pycbc user
+# The default command is now simpler as we are already the correct user
+CMD ["/bin/bash", "-l", "pycbc"]


### PR DESCRIPTION
## Summary 
There are cache memory checks present in `opt.py`. Sometimes PyCBC initialization fails in containers because its call to `getconf` cannot find details for the L3 cache -- it returns `undefined`.  

This issue happens only for L3 because containerization abstracts away shared, host-level hardware like the L3 cache for security and portability reasons. In contrast, information is available for L1 and L2 caches as their details are fundamental to the virtual core. 

PyCBC calls `getconf` directly query hardware details, completely ignoring any environment variables set to override these values.

## Solution 
A wrapper script is required to intercept the `getconf` system call itself. This allows us to provide a default value for the missing hardware information, preventing the crash.