### PR TITLE
Allowed filtering of four and five harmonics

### DIFF
--- a/bin/minifollowups/pycbc_plot_harmonic_waveform
+++ b/bin/minifollowups/pycbc_plot_harmonic_waveform
@@ -216,8 +216,8 @@ def compute_harmonic_waveform(trigs, special_idx, ifo, merge_psd_file,
     flen = int(sample_rate * segment_length/2+1)
     ncomp = trigs.bank['num_comps'][bad_tempid]
     # Hardcoded max numcomps for now:
-    if ncomp > 3:
-        ncomp = 3
+    if ncomp > 5:
+        ncomp = 5
 
     phenom_object = PhenomXPTemplate(params, sample_rate, f_lower)
 

--- a/pycbc/types/array_cpu.pyx
+++ b/pycbc/types/array_cpu.pyx
@@ -257,6 +257,128 @@ def whiten_and_normalize_three(
         h3[ii] = h3[ii] / sigmasq3
 
 
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.cdivision(True)
+def whiten_and_normalize_four(
+        double complex [:] h1,
+        double complex [:] h2,
+        double complex [:] h3,
+        double complex [:] h4,
+        float [:] ASD,
+        int flen,
+        float df,
+        int kmin,
+        int kmax
+):
+    cdef unsigned int ii
+    cdef double sigmasq1, sigmasq2, sigmasq3, sigmasq4
+
+    for ii in range(kmin, flen):
+        h1[ii] = h1[ii] / ASD[ii]
+        h2[ii] = h2[ii] / ASD[ii]
+        h3[ii] = h3[ii] / ASD[ii]
+        h4[ii] = h4[ii] / ASD[ii]
+
+    for ii in range(kmin):
+        h1[ii] = 0
+        h2[ii] = 0
+        h3[ii] = 0
+        h4[ii] = 0
+
+    for ii in range(kmax, flen):
+        h1[ii] = 0
+        h2[ii] = 0
+        h3[ii] = 0
+        h4[ii] = 0
+
+    sigmasq1 = 0
+    sigmasq2 = 0
+    sigmasq3 = 0
+    sigmasq4 = 0
+
+    for ii in range(flen):
+        sigmasq1 += (h1[ii].conjugate() * h1[ii]).real * 4. * df
+        sigmasq2 += (h2[ii].conjugate() * h2[ii]).real * 4. * df
+        sigmasq3 += (h3[ii].conjugate() * h3[ii]).real * 4. * df
+        sigmasq4 += (h4[ii].conjugate() * h4[ii]).real * 4. * df
+
+    sigmasq1 = sigmasq1**0.5
+    sigmasq2 = sigmasq2**0.5
+    sigmasq3 = sigmasq3**0.5
+    sigmasq4 = sigmasq4**0.5
+
+    for ii in range(flen):
+        h1[ii] = h1[ii] / sigmasq1
+        h2[ii] = h2[ii] / sigmasq2
+        h3[ii] = h3[ii] / sigmasq3
+        h4[ii] = h4[ii] / sigmasq4
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+@cython.cdivision(True)
+def whiten_and_normalize_five(
+        double complex [:] h1,
+        double complex [:] h2,
+        double complex [:] h3,
+        double complex [:] h4,
+        double complex [:] h5,
+        float [:] ASD,
+        int flen,
+        float df,
+        int kmin,
+        int kmax
+):
+    cdef unsigned int ii
+    cdef double sigmasq1, sigmasq2, sigmasq3, sigmasq4, sigmasq5
+
+    for ii in range(kmin, flen):
+        h1[ii] = h1[ii] / ASD[ii]
+        h2[ii] = h2[ii] / ASD[ii]
+        h3[ii] = h3[ii] / ASD[ii]
+        h4[ii] = h4[ii] / ASD[ii]
+        h5[ii] = h5[ii] / ASD[ii]
+
+    for ii in range(kmin):
+        h1[ii] = 0
+        h2[ii] = 0
+        h3[ii] = 0
+        h4[ii] = 0
+        h5[ii] = 0
+
+    for ii in range(kmax, flen):
+        h1[ii] = 0
+        h2[ii] = 0
+        h3[ii] = 0
+        h4[ii] = 0
+        h5[ii] = 0
+
+    sigmasq1 = 0
+    sigmasq2 = 0
+    sigmasq3 = 0
+    sigmasq4 = 0
+    sigmasq5 = 0
+
+    for ii in range(flen):
+        sigmasq1 += (h1[ii].conjugate() * h1[ii]).real * 4. * df
+        sigmasq2 += (h2[ii].conjugate() * h2[ii]).real * 4. * df
+        sigmasq3 += (h3[ii].conjugate() * h3[ii]).real * 4. * df
+        sigmasq4 += (h4[ii].conjugate() * h4[ii]).real * 4. * df
+        sigmasq5 += (h5[ii].conjugate() * h5[ii]).real * 4. * df
+
+    sigmasq1 = sigmasq1**0.5
+    sigmasq2 = sigmasq2**0.5
+    sigmasq3 = sigmasq3**0.5
+    sigmasq4 = sigmasq4**0.5
+    sigmasq5 = sigmasq5**0.5
+
+    for ii in range(flen):
+        h1[ii] = h1[ii] / sigmasq1
+        h2[ii] = h2[ii] / sigmasq2
+        h3[ii] = h3[ii] / sigmasq3
+        h4[ii] = h4[ii] / sigmasq4
+        h5[ii] = h5[ii] / sigmasq5
+
 def abs_arg_max_complex(numpy.ndarray [COMPLEXTYPE, ndim=1] a):
     cdef unsigned int xmax = a.shape[0]
     cdef double mag

--- a/pycbc/waveform/bank.py
+++ b/pycbc/waveform/bank.py
@@ -1454,9 +1454,17 @@ class _PhenomTemplate():
         return h1, h2, h3, h4, h5
 
     def wn_cython(self, hs, ASD, flen, df, kmin, kmax):
+        from pycbc.types.array_cpu import whiten_and_normalize_five
+        from pycbc.types.array_cpu import whiten_and_normalize_four
         from pycbc.types.array_cpu import whiten_and_normalize_three
         from pycbc.types.array_cpu import whiten_and_normalize_two
         from pycbc.types.array_cpu import whiten_and_normalize_one
+        if len(hs) == 5:
+            whiten_and_normalize_five(hs[0].data, hs[1].data, hs[2].data, hs[3].data, hs[4].data,
+                                       ASD.data, flen, df, kmin, kmax)
+        if len(hs) == 4:
+            whiten_and_normalize_four(hs[0].data, hs[1].data, hs[2].data, hs[3].data,
+                                       ASD.data, flen, df, kmin, kmax)
         if len(hs) == 3:
             whiten_and_normalize_three(hs[0].data, hs[1].data, hs[2].data,
                                        ASD.data, flen, df, kmin, kmax)
@@ -1468,7 +1476,7 @@ class _PhenomTemplate():
 
 
     def whiten_and_normalize(self, hs, ASD, flen, df, kmin, kmax):
-        if len(hs) in [3,2,1]:
+        if len(hs) in [5,4,3,2,1]:
             self.wn_cython(hs, ASD, flen, df, kmin, kmax)
             return
         raise NotImplementedError()


### PR DESCRIPTION
<!---
Allowed filtering of 4 and 5 harmonics
-->

<!---
-->

<!-- Extended bank.py to allow the filtering of 4 and 5 harmonics
-->

## Standard information about the request

<!--- Some basic info about the change (delete as appropriate) -->
Extended bank.py to allow the filtering of 4 and 5 harmonics

<!--- What codes will this affect? (delete as apropriate)
If you do not know which areas will be affected, please ask in the gwastro #pycbc-code slack
-->
This change affects: precessing search

<!--- What code areas will this affect? (delete as apropriate) -->
This change changes: matched filtering/template generation

## Motivation
<!--- Describe why your changes are being made -->
So we can filter with the full 5 harmonic decomposition.
## Contents
<!--- Describe your changes, this doesn't need to be a line-by-line code change discussion,
but rather a general discussion of the methods chosen -->
Just an extension of previous existing code to include 4 and 5 harmonics
## Links to any issues or associated PRs
<!--- If this is fixing / working around an already-reported issue, please link to it here -->

## Testing performed
<!--- Describe tests for the code changes, either already performed or to be performed -->
Successful runs using this code. Note there may be some issues in template generation for some 'perturbed aligned spin' templates.
## Additional notes
<!--- Anything which does not fit in the above sections -->

- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
